### PR TITLE
fix: 左右面板同步

### DIFF
--- a/src/panels/date/index.vue
+++ b/src/panels/date/index.vue
@@ -167,9 +167,6 @@ export default {
   data() {
     return {
       pickerPrefixCls: getPrefixCls('picker'),
-      localCurrentView: !isUndefined(this.currentView)
-        ? this.currentView
-        : 'date',
     };
   },
   watch: {
@@ -191,13 +188,12 @@ export default {
     },
     showDateView() {
       return (
-        !this.showTime || !this.showViewTabs || this.localCurrentView === 'date'
+        !this.showTime || !this.showViewTabs || this.currentView === 'date'
       );
     },
     showTimeView() {
       return (
-        this.showTime &&
-        (!this.showViewTabs || this.localCurrentView === 'time')
+        this.showTime && (!this.showViewTabs || this.currentView === 'time')
       );
     },
     classNames() {
@@ -295,7 +291,6 @@ export default {
     changeViewTo(newView) {
       this.$emit('currentViewChange', newView);
       this.$emit('update:currentView', newView);
-      this.localCurrentView = newView;
     },
   },
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR and contribution. -->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Component style change
- [ ] Typescript definition change
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Breaking change
- [ ] Others

## Background and context
解决`范围选择器`点击时间选择时 只切换了一边没有同步问题


